### PR TITLE
Adding new functions to argparser and config components

### DIFF
--- a/argparser/argparser.go
+++ b/argparser/argparser.go
@@ -1,14 +1,11 @@
 package argparser
 
 import (
-	"bytes"
+	"config"
 	"flag"
 	"fmt"
-	"io/ioutil"
-	"os/exec"
+	"os"
 	"strings"
-
-	"gopkg.in/yaml.v2"
 )
 
 //Greet function for testcase
@@ -16,86 +13,32 @@ func Greet() {
 	fmt.Println("Hello World Argparse!")
 }
 
-//Tool structure for tool specific values in config file
-type Tool struct {
-	ToolEnvars []string `yaml:"ToolEnvars"`
-	Match      string   `yaml:"Match"`
-}
+//ArgParse funtion to parse arguments
+func ArgParse() (config.Config, string) {
 
-//CacheConfig -- Cache configure file values
-type CacheConfig struct {
-	ToolIdx int      `yaml:"ToolIdx"`
-	Envars  []string `yaml:"Envars"`
-	Tools   []Tool   `yaml:"Tool"`
-}
-
-//RunCmd -- To exectue shell commands
-func RunCmd(command string) (string, string) {
-	cmd := exec.Command("bash", "-c", command)
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	cmd.Run()
-	return stdout.String(), stderr.String()
-}
-
-//runArgParser funtion to parse arguments
-func runArgParser() {
-
-	//parsing the CLI arguments
-	mode := flag.String("mode", "active",
-		"Wiskcache operating mode. Possible values - active, learning, verify")
+	var defaultConfigFile string = os.Getenv("wiskcache_config")
+	mode := flag.String("mode", "active", "Wiskcache operating mode. Possible values - active, learning, verify")
 	var InputconfigFile string
-	flag.StringVar(&InputconfigFile, "config", "<default_config_file_location>", "Wiskcache configure file location")
-	baseDir := flag.String("base_dir", "",
-		"Wiskcache will rewrite absolute paths beginning with base_dir into paths relative to the current working directory")
+	flag.StringVar(&InputconfigFile, "config", defaultConfigFile, "Wiskcache configure file location")
+	baseDir := flag.String("base_dir", "", "Wiskcache will rewrite absolute paths beginning with base_dir into paths relative to the current working directory")
 	flag.Parse()
 	remainingArgs := flag.Args()
-	cmdLine := strings.Join(remainingArgs, " ")
+	CommandLine := strings.Join(remainingArgs, " ")
 
-	//printing out parsed CLI arguments
-	fmt.Println("--------------------------------------------------------------------------------------------------------")
-	fmt.Println("Wiskcache Base Directory -- ", *baseDir)
-	fmt.Println("--------------------------------------------------------------------------------------------------------")
-	fmt.Printf("\nWiskcache is operating in '%s' mode\n", *mode)
-	fmt.Println("--------------------------------------------------------------------------------------------------------")
-	fmt.Println("Wiskcache configuration file location -- ", InputconfigFile)
+	var ConfigValues config.Config
 
-	//parsing the input configure file
-	ConfigFile, err := ioutil.ReadFile(InputconfigFile)
-	if err != nil {
-		fmt.Printf("Error reading Wiskcache configure file: %s\n", err)
-		return
-	}
-	var ConfigValues CacheConfig
-	err = yaml.Unmarshal(ConfigFile, &ConfigValues)
-	if err != nil {
-		fmt.Printf("Error parsing Wiskcache configure file: %s\n", err)
+	//Parsing config file to get Configvalues instance
+	if InputconfigFile != "" {
+		ConfigValues = config.Parseconfig(InputconfigFile)
 	}
 
-	fmt.Println("Configuration file contents -- ")
-	//printing out Key-Value pairs of parsed configure file
-	fmt.Println("Tool Index -- ", ConfigValues.ToolIdx)
-	fmt.Println("Environment Variables -- ", ConfigValues.Envars)
+	//ToolIndex default value set to -1
+	ConfigValues.ToolIdx = -1
 
-	var Toolsno int
-	Toolsno = len(ConfigValues.Tools)
+	//Adding the Wiskcache Mode and Base directory information to Config instance
+	ConfigValues.Mode = *mode
+	ConfigValues.BaseDir = *baseDir
 
-	for i := 0; i < Toolsno; i++ {
-		fmt.Println("	Match -- ", ConfigValues.Tools[i].Match)
-		fmt.Println("	Tool Environment Variables -- ", ConfigValues.Tools[i].ToolEnvars)
-	}
-	fmt.Println("--------------------------------------------------------------------------------------------------------")
-	fmt.Println("Command line after Wiskcache flags -- ", cmdLine)
-	//fmt.Println("cmd_line_list -- ", remainingArgs)
+	return ConfigValues, CommandLine
 
-	//running shell command obtained from CLI and printing output and error
-	fmt.Println("Error and output of running the above command line")
-	output, errorOut := RunCmd(cmdLine)
-	fmt.Println("---stderr---")
-	fmt.Println(errorOut)
-	fmt.Println("---stdout---")
-	fmt.Println(output)
-	fmt.Println("--------------------------------------------------------------------------------------------------------")
 }

--- a/argparser/go.mod
+++ b/argparser/go.mod
@@ -1,7 +1,10 @@
-module cache
+module argparser
 
 go 1.16
 
+replace config => ../config
+
 require (
-gopkg.in/yaml.v2 v2.4.0
+	config v0.0.0-00010101000000-000000000000 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/config/config.go
+++ b/config/config.go
@@ -1,21 +1,62 @@
 package config
 
-import "fmt"
+import (
+	"fmt"
+	"io/ioutil"
+	"regexp"
+	"strings"
 
+	"gopkg.in/yaml.v2"
+)
+
+//Tool specific config values
 type Tool struct {
-	Match  string
-	Envars []string
+	Match      string   `yaml:"Match"`
+	ToolEnvars []string `yaml:"ToolEnvars"`
 }
 
-// declaring a student struct
+//Config structure declaration
 type Config struct {
-	// declaring struct variables
-	BaseDir string
-	Envars  []string
-	Tools   []Tool
-	ToolIdx int
+	ToolIdx int      `yaml:"ToolIdx"`
+	Mode    string   `yaml:"Mode"`
+	BaseDir string   `yaml:"BaseDir"`
+	Envars  []string `yaml:"Envars"`
+	Tools   []Tool   `yaml:"Tool"`
 }
 
+//Greet function for testing
 func Greet() {
 	fmt.Println("Hello World Config!")
+}
+
+//Parseconfig function to parse the config file
+func Parseconfig(InputconfigFile string) Config {
+	ConfigFile, err := ioutil.ReadFile(InputconfigFile)
+	if err != nil {
+		fmt.Printf("Error reading Wiskcache configure file: %s\n", err)
+	}
+	var ConfigValues Config
+	err = yaml.Unmarshal(ConfigFile, &ConfigValues)
+	if err != nil {
+		fmt.Printf("Error parsing Wiskcache configure file: %s\n", err)
+	}
+	return ConfigValues
+}
+
+//ToolMatcher fuction to match the Tool name with the Tool information in config file
+func ToolMatcher(ConfigValues Config, CommandLine string) int {
+
+	var matched bool
+	var err error
+	var idx int = -1
+	var Toolsno int = len(ConfigValues.Tools)
+	var Toolname string = strings.Split(CommandLine, " ")[0]
+	for i := 0; i < Toolsno; i++ {
+		matched, err = regexp.MatchString(Toolname, ConfigValues.Tools[i].Match)
+		if matched && err == nil {
+			idx = i
+			break
+		}
+	}
+	return idx
 }

--- a/config/go.mod
+++ b/config/go.mod
@@ -1,3 +1,5 @@
 module config
 
 go 1.16
+
+require gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/main.go
+++ b/main.go
@@ -41,6 +41,24 @@ func main() {
 	} else {
 		fmt.Println("No")
 	}
+
+	var ConfigValues config.Config
+	var CommandtoExec string
+
+	ConfigValues, CommandtoExec = argparser.ArgParse()
+	ConfigValues.ToolIdx = config.ToolMatcher(ConfigValues, CommandtoExec)
+
+	fmt.Println("Wiskcache Mode -- ", ConfigValues.Mode)
+	fmt.Println("Wiskcache Base Dir -- ", ConfigValues.BaseDir)
+	fmt.Println("Common Envars from config file -- ", ConfigValues.Envars)
+	fmt.Println("Command to be executed -- ", CommandtoExec)
+	if ConfigValues.ToolIdx != -1 {
+		fmt.Println("Tool Match Found")
+		fmt.Println("Tool Specific Envars -- ", ConfigValues.Tools[ConfigValues.ToolIdx])
+	} else {
+		fmt.Println("Tool Match Not Found")
+	}
+
 	cache.Greet()
 	exec.Greet()
 	config.Greet()


### PR DESCRIPTION
Adding the argparser calls and functionality to the config component.

abmuruge@ABMURUGE-M-4285 wiskcache % ./wiskcache -base_dir /ws/base/path -config /Users/abmuruge/go/src/wiskcache/config_test.yaml -- gcc -o t1.o t1.c
Wiskcache Mode --  active
Wiskcache Base Dir --  /ws/base/path
Common Envars from config file --  [var1 var2]
Command to be executed --  gcc -o t1.o t1.c
Tool Match Found
Tool Specific Envars --  {gcc [qwe rty uio]}