### PR TITLE
Fixing the regex call in config.go and adding the new modes

### DIFF
--- a/argparser/argparser.go
+++ b/argparser/argparser.go
@@ -23,7 +23,7 @@ func contains(s []string, str string) bool {
 func ArgParse() (ConfigValues config.Config, CommandLine string) {
 
 	var defaultConfigFile string = os.Getenv("WISKCACHE_CONFIG")
-	mode := flag.String("mode", "active", "Wiskcache operating mode. Possible values - active, learning, verify")
+	mode := flag.String("mode", "readwrite", "Wiskcache operating mode. Possible values - readonly, writeonly, readwrite, learn, verify")
 	var InputconfigFile string
 	flag.StringVar(&InputconfigFile, "config", defaultConfigFile, "Wiskcache configure file location")
 	baseDir := flag.String("base_dir", "", "Wiskcache will rewrite absolute paths beginning with base_dir into paths relative to the current working directory")
@@ -32,9 +32,9 @@ func ArgParse() (ConfigValues config.Config, CommandLine string) {
 	CommandLine = strings.Join(remainingArgs, " ")
 
 	//Validating arguments
-	ModeValues := []string{"active", "learning", "verify"}
+	ModeValues := []string{"readonly", "writeonly", "readwrite", "learn", "verify"}
 	if !contains(ModeValues, *mode) {
-		fmt.Println("Invalid mode. Possible values - active, learning, verify")
+		fmt.Println("Invalid mode. Possible values - readonly, writeonly, readwrite, learn, verify")
 		os.Exit(1)
 	}
 
@@ -53,8 +53,12 @@ func ArgParse() (ConfigValues config.Config, CommandLine string) {
 	ConfigValues.ToolIdx = -1
 
 	//Adding the Wiskcache Mode and Base directory information to Config instance
-	ConfigValues.Mode = *mode
-	ConfigValues.BaseDir = *baseDir
+	if *mode != "" {
+		ConfigValues.Mode = *mode
+	}
+	if *baseDir != "" {
+		ConfigValues.BaseDir = *baseDir
+	}
 
 	return
 

--- a/config/config.go
+++ b/config/config.go
@@ -47,7 +47,7 @@ func ToolMatcher(ConfigValues Config, CommandLine string) (idx int) {
 	var Toolsno int = len(ConfigValues.Tools)
 	var Toolname string = strings.Split(CommandLine, " ")[0]
 	for i := 0; i < Toolsno; i++ {
-		matched, err = regexp.MatchString(Toolname, ConfigValues.Tools[i].Match)
+		matched, err = regexp.MatchString(ConfigValues.Tools[i].Match, Toolname)
 		if matched && err == nil {
 			idx = i
 			break


### PR DESCRIPTION
The order of arguments in regex call needed to be switched.

Adding the new modes -- readonly, writeonly and readwrite

Overriding the default baseDir and mode values with CLI arguments